### PR TITLE
Add Gridsmart to Device Status and Ops Overview

### DIFF
--- a/components/css/dashboard.css
+++ b/components/css/dashboard.css
@@ -206,7 +206,18 @@ p.quote-of-the-week {
 }
 
 .info-metric {
+  /* dash panel and signal retiming */
   font-size: 5em;
+  text-align: left;
+  dominant-baseline: bottom;
+  -webkit-user-select: none; /* Chrome/Safari */        
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* IE10+ */
+}
+
+.info-metric-small {
+  /* dash panel and signal retiming */
+  font-size: 2.5em;
   text-align: left;
   dominant-baseline: bottom;
   -webkit-user-select: none; /* Chrome/Safari */        

--- a/components/js/device-status.js
+++ b/components/js/device-status.js
@@ -1,10 +1,4 @@
 // assumes one record per device-type per location
-// to do:
-// align table icons
-// checkbox data selctors
-// status pop-ups in data table
-// map expander
-// home button
 
 var data_master, map, marker, feature_layer, table, filters, default_bounds, curr_breakpoint;
 
@@ -31,9 +25,9 @@ var device_data = [
         'name' : 'gridsmart',
         'icon' : 'crosshairs',
         'display_name' : "<i class='fa fa-crosshairs'></i> GRIDSMART",
-        'resource_id' : 'fs3c-45ge',
+        'resource_id' : 'sqwb-zh93',  // qpuw-8eeb
         'id_field' : 'atd_camera_id',
-        'query' : 'select * where upper(camera_mfg) LIKE ("%25GRIDSMART%25")'
+        'query' : 'select * where upper(detector_type) LIKE ("%25GRIDSMART%25")'
     },
     {
         'name' : 'travel_sensor',
@@ -314,6 +308,12 @@ function groupByLocation(data) {
                 //  build location record        
                 var device_name = device_data[i]['name'];
                 
+                if (!(device_data[i].data[q].latitude) && device_data[i].data[q].location) {
+                    device_data[i].data[q].longitude = device_data[i].data[q].location.coordinates[0]
+                    device_data[i].data[q].latitude = device_data[i].data[q].location.coordinates[1]
+                    
+                }
+
                 var new_loc = {
                     'location' : location,
                     'latitude' : device_data[i].data[q].latitude,
@@ -704,11 +704,3 @@ function resizedw(){
 
     table.columns.adjust();
 }
-
-
-
-
-
-
-
-

--- a/components/js/ops-overview.js
+++ b/components/js/ops-overview.js
@@ -123,7 +123,6 @@ var config = [
         'icon' : 'clock-o',
         'init_val' : 0,
         'format' : 'round',
-        'data' : [140],
         'infoStat' : true,
         'caption' : 'Traffic signals retimied this fiscal year',
         'query' : 'SELECT SUM(signal_count) as count WHERE retime_status IN ("COMPLETED") and scheduled_fy in ("' + fiscal_year + '")',
@@ -158,6 +157,20 @@ var config = [
         'resource_id' : 'xwqn-2f78',
         'data_transform' : function(x) { return( [x[0]['count']] )},
         'update_event' : 'signals_update'
+    }, 
+    {
+        'id' : 'gridsmart',
+        'row_container_id' : 'panel-row-1',
+        'display_name' : 'Gridsmart',
+        'icon' : 'crosshairs',
+        'init_val' : 0,
+        'format' : 'round',
+        'infoStat' : true,
+        'caption' : 'Gridsmart detection cameras installed',
+        'query' : 'select count(detector_id) as count where upper(detector_type) in ("GRIDSMART")',
+        'resource_id' : 'sqwb-zh93',
+        'data_transform' : function(x) { return( [x[0]['count']] )},
+        'update_event' : 'detectors_update'
     }
     // {
     //     'id' : 'school-beacons',
@@ -302,7 +315,7 @@ function appendInfoText(data) {
         .attr('class', 'col')
 
     panel_content.append('text')
-        .attr('class', 'info-metric')
+        .attr('class', 'info-metric-small')
         .text(function(d) {
             return d.init_val;
         });
@@ -329,7 +342,7 @@ function transitionInfoStat(selection, options) {
         .ease(options.ease)
         .duration(options.duration);
 
-    selection.selectAll('.info-metric')
+    selection.selectAll('.info-metric-small')
         .transition(t)  //  do this for each selection in sequence
         .tween('text', function () {
             
@@ -383,7 +396,6 @@ function postUpdateDate(selection, resource_id, event) {
                     .attr('class', 'row')
                     .append('div')
                     .attr('class', 'col')
-                    // .select('.info-metric')
                     .append('h6')
                     .attr("class", "dash-panel-footer-text text-left")
                     .html("Updated " + update_date + " at " + update_time + 


### PR DESCRIPTION
Prior to this update, Gridsmart traffic detectors were not available on the device status dashboard--the filter button was merely a placeholder. We now have Traffic Detectors dataset on Socrata, which makes the Gridsmart camera info available to be ingested by the device status page.

We also add the necessary conifg info to ops-overview.js so that a gridsmart asset count is displayed on the ops overview dashboard. And we've also reduced the size of dash panel metrics because things were getting a bit crowded.