### PR TITLE
Host CSS and JS locally

### DIFF
--- a/_includes/default-scripts.html
+++ b/_includes/default-scripts.html
@@ -3,7 +3,7 @@
 <script src='/components/js/d3.v4.min.js' type="text/javascript"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 <script src="/components/js/jquery.dataTables.min.js"></script>
-<script src="https://unpkg.com/leaflet@1.1.0/dist/leaflet.js"></script>
+<script src="/components/js/leaflet.js"></script>
 <script src='/components/js/viewport_checker.js' type="text/javascript"></script>
 <script src='/components/js/quote-of-the-week.js' type="text/javascript"></script>
 <script src='/components/js/google-analytics.js' type="text/javascript"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,8 +9,8 @@
     <meta name="description" content="{{  page.description }}">
     <title>{{ page.title }}</title>
 
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">    
+    <link rel="stylesheet" href="/components/css/leaflet.css" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="/components/css/jquery.dataTables.min.css" media="screen" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=News+Cycle' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
All of our map pages broke today because leaflet removed a point release of their CSS from their CDN. With this commit we're hosting copies of the JS and CSS locally.