### PR TITLE
No Underline For Navbutton Text

### DIFF
--- a/components/css/custom.css
+++ b/components/css/custom.css
@@ -84,3 +84,7 @@ span.col-14, span.col-15 {
   padding: 0px;
 }
 
+.nav-homepage:hover{
+  text-decoration: none;
+}
+


### PR DESCRIPTION
Hey @johnclary just showing I am familiar with Git, as well as collaborating on a repo. I made a small change to the Navbutton on the home page to remove the underline on hover. I believe this makes the interface more enjoyable. If you don't want to merge that is okay, this is mostly just a demonstration of my eagerness. Thanks!